### PR TITLE
Fix getfields API params

### DIFF
--- a/includes/class-cvc-display.php
+++ b/includes/class-cvc-display.php
@@ -253,7 +253,7 @@ class Content_Views_CiviCRM_Display {
 	 */
 	public function get_fields_for( $entity, $action ) {
 
-		return $this->cvc->api->call_values( $entity, 'getfields', [ 'action' => $action ] );
+		return $this->cvc->api->call_values( $entity, 'getfields', [ 'api_action' => $action ] );
 
 	}
 


### PR DESCRIPTION
@agileware-justin Small extraction from https://github.com/agileware/content-views-civicrm-data-processor/pull/3 that should be ready to merge.

getfields was using the wrong parameter for the api and causing civi to use generic getfields instead of the dataprocessor getfields.