### PR TITLE
Fix duplicated results

### DIFF
--- a/includes/class-cvc-query.php
+++ b/includes/class-cvc-query.php
@@ -164,6 +164,9 @@ class Content_Views_CiviCRM_Query {
 			$dp     = array_shift( $dp );
 			$result = $this->cvc->api->call_values( $dp['api_entity'], $dp['api_action'], $args['civicrm_api_params'] );
 
+			// clear posts from previous short codes
+			$posts = [];
+
 			// mock WP_Posts contacts
 			foreach ( $result as $item ) {
 				$post                    = new WP_Post( (object) [] );


### PR DESCRIPTION
The setup:
- 2 data processors
- 2 content views
- 2 short codes
- 1 page

The 2nd short code displayed on a page is also displaying results from the first short code. I have tried changing the order and well as checking the raw return from the data processor API call. All work as expected.

It seems to me, the Content Views plugin is caching results from previous displays, but I honestly did not get that far down rabbit hole.

The changes in this pull request fixed the issue for me without any side effects, however I am only using the plugin in a very limited manner. https://github.com/agileware/content-views-civicrm-data-processor/issues/15